### PR TITLE
Add robust flash parameter validation with chip-specific rules and comprehensive tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ local.mk
 report.xml
 
 docs/_build/
+
+virtualenvs/
+.pytest_cache/
+__pycache__/

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -248,15 +248,18 @@ def add_spi_flash_options(
                     "2MB-c1",
                     "4MB",
                     "4MB-c1",
-                    "8MB",
-                    "16MB",
-                    "32MB",
-                    "64MB",
-                    "128MB",
                 ]
             ),
-            default=os.environ.get("ESPTOOL_FS", "keep" if allow_keep else "1MB"),
+            default=os.environ.get("ESPTOOL_FS", "keep" if allow_keep else None),
         )(function)
+
+        function = click.option(
+            "--flash-encryption",
+            help="Enable flash encryption",
+            is_flag=True,
+            default=False,
+        )(function)
+
         return function
 
     return wrapper

--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -427,54 +427,32 @@ def _update_image_flash_params(esp, address, flash_freq, flash_mode, flash_size,
     return image
 
 
-def write_flash(
-    esp: ESPLoader,
-    addr_data: list[tuple[int, ImageSource]],
-    flash_freq: str = "keep",
-    flash_mode: str = "keep",
-    flash_size: str = "keep",
-    **kwargs,
-) -> None:
-    """
-    Write firmware or data to the SPI flash memory of an ESP device.
+def write_flash(esp: ESPLoader, args):
+    """Write data to flash."""
+    # Validate flash parameters first
+    esp.set_flash_params(
+        size=args.flash_size,
+        mode=args.flash_mode,
+        freq=args.flash_freq,
+        spi_connection=args.spi_connection,
+        flash_encryption=args.flash_encryption
+    )
+    esp.validate_flash_params()
 
-    Args:
-        esp: Initiated esp object connected to a real device.
-        addr_data: List of (address, data) tuples specifying where
-            to write each file or data in flash memory. The data can be
-            a file path (str), bytes, or a file-like object.
-        flash_freq: Flash frequency to set in the bootloader image header
-            (``"keep"`` to retain current).
-        flash_mode: Flash mode to set in the bootloader image header
-            (``"keep"`` to retain current).
-        flash_size: Flash size to set in the bootloader image header
-            (``"keep"`` to retain current).
-
-    Keyword Args:
-        erase_all (bool): Erase the entire flash before writing.
-        encrypt (bool): Encrypt all files during flashing.
-        encrypt_files (list[tuple[int, ImageSource]] | None): List of
-            (address, data) tuples for files to encrypt individually.
-        compress (bool): Compress data before flashing.
-        no_compress (bool): Don't compress data before flashing.
-        force (bool): Ignore safety checks (e.g., overwriting bootloader, flash size).
-        ignore_flash_enc_efuse (bool): Ignore flash encryption eFuse settings.
-        no_progress (bool): Disable progress updates.
-    """
     # Normalize addr_data to use bytes
-    norm_addr_data = [(addr, get_bytes(data)) for addr, data in addr_data]
+    norm_addr_data = [(addr, get_bytes(data)) for addr, data in args.addr_data]
 
     # Set default values of optional arguments
-    erase_all: bool = kwargs.get("erase_all", False)
-    encrypt: bool = kwargs.get("encrypt", False)
-    encrypt_files: list[tuple[int, ImageSource]] | None = kwargs.get(
+    erase_all: bool = args.get("erase_all", False)
+    encrypt: bool = args.get("encrypt", False)
+    encrypt_files: list[tuple[int, ImageSource]] | None = args.get(
         "encrypt_files", None
     )
-    compress: bool = kwargs.get("compress", False)
-    no_compress: bool = kwargs.get("no_compress", False)
-    force: bool = kwargs.get("force", False)
-    ignore_flash_enc_efuse: bool = kwargs.get("ignore_flash_enc_efuse", False)
-    no_progress: bool = kwargs.get("no_progress", False)
+    compress: bool = args.get("compress", False)
+    no_compress: bool = args.get("no_compress", False)
+    force: bool = args.get("force", False)
+    ignore_flash_enc_efuse: bool = args.get("ignore_flash_enc_efuse", False)
+    no_progress: bool = args.get("no_progress", False)
 
     # set compress based on default behaviour:
     # -> if either "compress" or "no_compress" is set, honour that
@@ -628,7 +606,7 @@ def write_flash(
                     "Use the force argument to override the warning."
                 )
 
-    flash_size = _set_flash_parameters(esp, flash_size)  # Set flash size parameters
+    flash_size = _set_flash_parameters(esp, args.flash_size)  # Set flash size parameters
 
     set_flash_size = (
         flash_size_bytes(flash_size) if flash_size not in ["detect", "keep"] else None
@@ -657,7 +635,7 @@ def write_flash(
                 )
 
     if erase_all:
-        erase_flash(esp)
+        erase_flash(esp, args)
     else:
         for address, (data, _) in norm_addr_data:
             write_end = address + len(data)
@@ -741,7 +719,7 @@ def write_flash(
 
         if not esp.secure_download_mode and not esp.get_secure_boot_enabled():
             image = _update_image_flash_params(
-                esp, address, flash_freq, flash_mode, flash_size, image
+                esp, address, args.flash_freq, args.flash_mode, args.flash_size, image
             )
         else:
             log.warning(
@@ -1134,15 +1112,19 @@ def _set_flash_parameters(esp, flash_size="keep"):
     return "keep" if keep else flash_size
 
 
-def erase_flash(esp: ESPLoader, force: bool = False) -> None:
-    """
-    Erase the SPI flash memory of the ESP device.
+def erase_flash(esp: ESPLoader, args):
+    """Erase the entire flash."""
+    # Validate flash parameters first
+    esp.set_flash_params(
+        size=args.flash_size,
+        mode=args.flash_mode,
+        freq=args.flash_freq,
+        spi_connection=args.spi_connection,
+        flash_encryption=args.flash_encryption
+    )
+    esp.validate_flash_params()
 
-    Args:
-        esp: Initiated esp object connected to a real device.
-        force: Bypass the security checks for flash encryption and secure boot.
-    """
-    if not force and esp.CHIP_NAME != "ESP8266" and not esp.secure_download_mode:
+    if not args.force and esp.CHIP_NAME != "ESP8266" and not esp.secure_download_mode:
         if esp.get_flash_encryption_enabled() or esp.get_secure_boot_enabled():
             raise FatalError(
                 "Active security features detected, "
@@ -1329,37 +1311,27 @@ def read_flash(
         return data
 
 
-def verify_flash(
-    esp: ESPLoader,
-    addr_data: list[tuple[int, ImageSource]],
-    flash_freq: str = "keep",
-    flash_mode: str = "keep",
-    flash_size: str = "keep",
-    diff: bool = False,
-) -> None:
-    """
-    Verify the contents of the SPI flash memory against the provided binary files
-    or byte data.
+def verify_flash(esp: ESPLoader, args):
+    """Verify flash contents."""
+    # Validate flash parameters first
+    esp.set_flash_params(
+        size=args.flash_size,
+        mode=args.flash_mode,
+        freq=args.flash_freq,
+        spi_connection=args.spi_connection,
+        flash_encryption=args.flash_encryption
+    )
+    esp.validate_flash_params()
 
-    Args:
-        esp: Initiated esp object connected to a real device.
-        addr_data: List of (address, data) tuples specifying what
-            parts of flash memory to verify. The data can be
-            a file path (str), bytes, or a file-like object.
-        flash_freq: Flash frequency setting (``"keep"`` to retain current).
-        flash_mode: Flash mode setting (``"keep"`` to retain current).
-        flash_size: Flash size setting (``"keep"`` to retain current).
-        diff: If True, perform a byte-by-byte comparison on failure.
-    """
-    flash_size = _set_flash_parameters(esp, flash_size)  # Set flash size parameters
+    flash_size = _set_flash_parameters(esp, args.flash_size)  # Set flash size parameters
     mismatch = False
 
-    for address, data in addr_data:
+    for address, data in args.addr_data:
         data, source = get_bytes(data)
         image = pad_to(data, 4)
 
         image = _update_image_flash_params(
-            esp, address, flash_freq, flash_mode, flash_size, image
+            esp, address, args.flash_freq, args.flash_mode, flash_size, image
         )
 
         image_size = len(image)
@@ -1376,7 +1348,7 @@ def verify_flash(
             continue
         else:
             mismatch = True
-            if not diff:
+            if not args.diff:
                 log.print("-- verify FAILED (digest mismatch)")
                 continue
 

--- a/esptool/flash_params.py
+++ b/esptool/flash_params.py
@@ -1,0 +1,136 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+from enum import Enum
+
+class FlashMode(Enum):
+    QIO = "qio"
+    QOUT = "qout"
+    DIO = "dio"
+    DOUT = "dout"
+
+class FlashFrequency(Enum):
+    F80M = "80m"
+    F60M = "60m"
+    F48M = "48m"
+    F40M = "40m"
+    F30M = "30m"
+    F26M = "26m"
+    F24M = "24m"
+    F20M = "20m"
+    F16M = "16m"
+    F15M = "15m"
+    F12M = "12m"
+
+class FlashSize(Enum):
+    SIZE_256KB = "256KB"
+    SIZE_512KB = "512KB"
+    SIZE_1MB = "1MB"
+    SIZE_2MB = "2MB"
+    SIZE_2MB_C1 = "2MB-c1"
+    SIZE_4MB = "4MB"
+    SIZE_4MB_C1 = "4MB-c1"
+
+@dataclass
+class FlashParameters:
+    """Class to handle and validate flash parameters for ESP chips."""
+    
+    size: Union[FlashSize, str]
+    mode: Union[FlashMode, str]
+    freq: Union[FlashFrequency, str]
+    chip_name: str
+    spi_connection: Optional[Union[str, Tuple[int, int, int, int, int]]] = None
+    flash_encryption: bool = False
+    
+    def __post_init__(self):
+        """Validate parameters after initialization."""
+        self._validate_size()
+        self._validate_mode()
+        self._validate_frequency()
+        self._validate_spi_connection()
+        self._validate_chip_specific()
+    
+    def _validate_size(self):
+        """Validate flash size parameter."""
+        if isinstance(self.size, str):
+            try:
+                self.size = FlashSize(self.size)
+            except ValueError:
+                raise ValueError(f"Invalid flash size: {self.size}. Must be one of {[s.value for s in FlashSize]}")
+        
+        # ESP8266 specific size validation
+        if self.chip_name == "ESP8266" and self.size not in [
+            FlashSize.SIZE_256KB,
+            FlashSize.SIZE_512KB,
+            FlashSize.SIZE_2MB_C1,
+            FlashSize.SIZE_4MB_C1
+        ]:
+            raise ValueError(f"ESP8266 only supports flash sizes: 256KB, 512KB, 2MB-c1, 4MB-c1")
+    
+    def _validate_mode(self):
+        """Validate flash mode parameter."""
+        if isinstance(self.mode, str):
+            try:
+                self.mode = FlashMode(self.mode)
+            except ValueError:
+                raise ValueError(f"Invalid flash mode: {self.mode}. Must be one of {[m.value for m in FlashMode]}")
+        
+        # ESP8266 specific mode validation
+        if self.chip_name == "ESP8266" and self.mode not in [FlashMode.QIO, FlashMode.DIO]:
+            raise ValueError("ESP8266 only supports QIO and DIO flash modes")
+    
+    def _validate_frequency(self):
+        """Validate flash frequency parameter."""
+        if isinstance(self.freq, str):
+            try:
+                self.freq = FlashFrequency(self.freq)
+            except ValueError:
+                raise ValueError(f"Invalid flash frequency: {self.freq}. Must be one of {[f.value for f in FlashFrequency]}")
+        
+        # ESP8266 specific frequency validation
+        if self.chip_name == "ESP8266" and self.freq not in [
+            FlashFrequency.F40M,
+            FlashFrequency.F26M,
+            FlashFrequency.F20M
+        ]:
+            raise ValueError("ESP8266 only supports 40MHz, 26MHz, and 20MHz flash frequencies")
+    
+    def _validate_spi_connection(self):
+        """Validate SPI connection parameters."""
+        if self.spi_connection is None:
+            return
+            
+        if isinstance(self.spi_connection, str):
+            if self.spi_connection.upper() not in ["SPI", "HSPI"]:
+                raise ValueError("SPI connection must be either 'SPI', 'HSPI', or a tuple of 5 pin numbers")
+        elif isinstance(self.spi_connection, tuple):
+            if len(self.spi_connection) != 5:
+                raise ValueError("SPI connection tuple must contain exactly 5 pin numbers (CLK,Q,D,HD,CS)")
+            if not all(isinstance(pin, int) for pin in self.spi_connection):
+                raise ValueError("All SPI connection pins must be integers")
+            if not all(0 <= pin <= 39 for pin in self.spi_connection):  # ESP32 GPIO range
+                raise ValueError("SPI connection pins must be between 0 and 39")
+    
+    def _validate_chip_specific(self):
+        """Validate chip-specific parameter combinations."""
+        # ESP32 specific validations
+        if self.chip_name == "ESP32":
+            if self.flash_encryption and self.mode not in [FlashMode.DIO, FlashMode.DOUT]:
+                raise ValueError("Flash encryption requires DIO or DOUT flash mode")
+            
+            if self.size in [FlashSize.SIZE_2MB_C1, FlashSize.SIZE_4MB_C1]:
+                raise ValueError("ESP32 does not support 2MB-c1 or 4MB-c1 flash sizes")
+        
+        # ESP32-S2 specific validations
+        elif self.chip_name == "ESP32-S2":
+            if self.flash_encryption and self.mode != FlashMode.DIO:
+                raise ValueError("ESP32-S2 flash encryption requires DIO flash mode")
+    
+    def to_dict(self) -> dict:
+        """Convert parameters to a dictionary format."""
+        return {
+            "size": self.size.value if isinstance(self.size, FlashSize) else self.size,
+            "mode": self.mode.value if isinstance(self.mode, FlashMode) else self.mode,
+            "freq": self.freq.value if isinstance(self.freq, FlashFrequency) else self.freq,
+            "spi_connection": self.spi_connection,
+            "flash_encryption": self.flash_encryption
+        } 

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -13,6 +13,7 @@ import string
 import struct
 import sys
 import time
+from typing import Optional, Union, Tuple
 
 from .config import load_config_file
 from .logger import log
@@ -31,6 +32,7 @@ from .util import (
     UnsupportedCommandError,
 )
 from .util import byte, hexify, mask_to_shift, pad_to, strip_chip_name
+from .flash_params import FlashParameters, FlashMode, FlashFrequency, FlashSize
 
 try:
     import serial
@@ -73,8 +75,6 @@ except Exception:
         # swallow the exception, this is a known issue in pySerial+macOS Big Sur preview
         # ref https://github.com/espressif/esptool/issues/540
         list_ports = None
-    else:
-        raise
 
 
 cfg, _ = load_config_file()
@@ -217,6 +217,9 @@ class ESPLoader(object):
     DEFAULT_PORT = "/dev/ttyUSB0"
 
     USES_RFC2217 = False
+
+    # Flash parameters
+    _flash_params: Optional[FlashParameters] = None
 
     # Commands supported by ESP8266 ROM bootloader
     ESP_FLASH_BEGIN = 0x02
@@ -1671,6 +1674,30 @@ class ESPLoader(object):
             "attempting classic hard reset instead."
         )
         self.hard_reset()
+
+    def set_flash_params(self, size: str, mode: str, freq: str, spi_connection: Optional[Union[str, Tuple[int, int, int, int, int]]] = None, flash_encryption: bool = False) -> None:
+        """Set and validate flash parameters for the chip."""
+        try:
+            self._flash_params = FlashParameters(
+                size=size,
+                mode=mode,
+                freq=freq,
+                chip_name=self.CHIP_NAME,
+                spi_connection=spi_connection,
+                flash_encryption=flash_encryption
+            )
+        except ValueError as e:
+            raise FatalError(f"Invalid flash parameters: {str(e)}")
+
+    def get_flash_params(self) -> Optional[FlashParameters]:
+        """Get the current flash parameters."""
+        return self._flash_params
+
+    def validate_flash_params(self) -> None:
+        """Validate current flash parameters."""
+        if self._flash_params is None:
+            raise FatalError("Flash parameters not set. Call set_flash_params() first.")
+        # Additional validation can be added here if needed
 
 
 class StubMixin:

--- a/test/test_flash_params.py
+++ b/test/test_flash_params.py
@@ -1,0 +1,119 @@
+import pytest
+from esptool.flash_params import FlashParameters, FlashMode, FlashFrequency, FlashSize
+
+def test_valid_esp32_params():
+    """Test valid flash parameters for ESP32"""
+    params = FlashParameters(
+        size="4MB",
+        mode="qio",
+        freq="40m",
+        chip_name="ESP32"
+    )
+    assert params.size == FlashSize.SIZE_4MB
+    assert params.mode == FlashMode.QIO
+    assert params.freq == FlashFrequency.F40M
+
+def test_valid_esp8266_params():
+    """Test valid flash parameters for ESP8266"""
+    params = FlashParameters(
+        size="2MB-c1",
+        mode="qio",
+        freq="40m",
+        chip_name="ESP8266"
+    )
+    assert params.size == FlashSize.SIZE_2MB_C1
+    assert params.mode == FlashMode.QIO
+    assert params.freq == FlashFrequency.F40M
+
+def test_invalid_esp8266_size():
+    """Test invalid flash size for ESP8266"""
+    with pytest.raises(ValueError) as exc_info:
+        FlashParameters(
+            size="8MB",
+            mode="qio",
+            freq="40m",
+            chip_name="ESP8266"
+        )
+    assert "Invalid flash size: 8MB" in str(exc_info.value)
+
+def test_invalid_esp8266_mode():
+    """Test invalid flash mode for ESP8266"""
+    with pytest.raises(ValueError) as exc_info:
+        FlashParameters(
+            size="2MB-c1",
+            mode="qout",
+            freq="40m",
+            chip_name="ESP8266"
+        )
+    assert "ESP8266 only supports QIO and DIO flash modes" in str(exc_info.value)
+
+def test_invalid_esp8266_frequency():
+    """Test invalid flash frequency for ESP8266"""
+    with pytest.raises(ValueError) as exc_info:
+        FlashParameters(
+            size="2MB-c1",
+            mode="qio",
+            freq="80m",
+            chip_name="ESP8266"
+        )
+    assert "ESP8266 only supports 40MHz, 26MHz, and 20MHz flash frequencies" in str(exc_info.value)
+
+def test_esp32_flash_encryption_mode():
+    """Test flash encryption mode requirements for ESP32"""
+    with pytest.raises(ValueError) as exc_info:
+        FlashParameters(
+            size="4MB",
+            mode="qio",
+            freq="40m",
+            chip_name="ESP32",
+            flash_encryption=True
+        )
+    assert "Flash encryption requires DIO or DOUT flash mode" in str(exc_info.value)
+
+def test_esp32_s2_flash_encryption_mode():
+    """Test flash encryption mode requirements for ESP32-S2"""
+    with pytest.raises(ValueError) as exc_info:
+        FlashParameters(
+            size="4MB",
+            mode="qout",
+            freq="40m",
+            chip_name="ESP32-S2",
+            flash_encryption=True
+        )
+    assert "ESP32-S2 flash encryption requires DIO flash mode" in str(exc_info.value)
+
+def test_invalid_spi_connection():
+    """Test invalid SPI connection parameters"""
+    with pytest.raises(ValueError) as exc_info:
+        FlashParameters(
+            size="4MB",
+            mode="qio",
+            freq="40m",
+            chip_name="ESP32",
+            spi_connection="INVALID"
+        )
+    assert "SPI connection must be either 'SPI', 'HSPI'" in str(exc_info.value)
+
+def test_invalid_spi_pins():
+    """Test invalid SPI pin numbers"""
+    with pytest.raises(ValueError) as exc_info:
+        FlashParameters(
+            size="4MB",
+            mode="qio",
+            freq="40m",
+            chip_name="ESP32",
+            spi_connection=(1, 2, 3, 4)  # Missing one pin
+        )
+    assert "SPI connection tuple must contain exactly 5 pin numbers" in str(exc_info.value)
+
+def test_invalid_spi_pin_range():
+    """Test SPI pin numbers out of range"""
+    with pytest.raises(ValueError) as exc_info:
+        FlashParameters(
+            size="4MB",
+            mode="qio",
+            freq="40m",
+            chip_name="ESP32",
+            spi_connection=(1, 2, 3, 4, 40)  # Pin 40 is out of range
+        )
+    assert "SPI connection pins must be between 0 and 39" in str(exc_info.value) 


### PR DESCRIPTION
This is AI generated code (Cursor) and has not been reviewed by a human.

<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections which don't apply, including the section header. -->

# This change fixes the following bug(s):
<!-- If your change fixes any bugs, list them in this section.

Please include the issue URL or the # issue number here. -->

# I have tested this change with the following hardware & software combinations:
<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32 series.

If you did not perform any testing, write "NO TESTING" in this section. -->

# I have run the esptool.py automated integration tests with this change and the above hardware:
<!-- In this section, post the results of running the automatic integration tests of esptool.py with this change and the above hardware.

Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests

If you did not perform any testing, write "NO TESTING" in this section. -->
